### PR TITLE
docs: add info about 'addDependencyTo' to fix Webpack refreshing styles problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ postcss: function(webpack) {
 },
 ```
 
+```javascript
+// postcss.config.js
+module.exports = function (webpack) {
+    const postcss = require('postcss'),
+    saladConfig = require('postcss-salad')(
+        {
+            //...
+            features: {
+                partialImport: {
+                    addDependencyTo: webpack.webpack
+                }
+            }
+        }
+    );
+
+    return saladConfig;
+};
+```
+
 [ci]: https://travis-ci.org/jonathantneal/postcss-partial-import
 [ci-img]: https://travis-ci.org/jonathantneal/postcss-partial-import.svg
 [Gulp PostCSS]: https://github.com/postcss/gulp-postcss


### PR DESCRIPTION
If we use postcss-salad in Webpack, changes in @import files are not reflected until full, manual rebuild. 

We have to pass 'addDependencyTo' flag with 'webpack' object to make it trackable.